### PR TITLE
Create enforce-pr.yml

### DIFF
--- a/.github/workflows/enforce-pr.yml
+++ b/.github/workflows/enforce-pr.yml
@@ -1,0 +1,17 @@
+name: Enforce Pull Requests to Main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  enforce-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR source branch
+        if: github.base_ref == 'main' && github.head_ref != 'develop'
+        run: |
+          echo "Les pull request ne sont autorisé que depuis develop."
+          exit 1


### PR DESCRIPTION
Fait en sorte que les PR vers le main ne soient possible que depuis Develop