### PR TITLE
chore: update .gitattributes to refine language statistics on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,17 @@
 # Binary files should be left untouched
 *.jar           binary
 
+# Exclude files from being counted by linguist
+*.css           linguist-vendored
+*.scss          linguist-vendored
+*.html          linguist-vendored
+*.js            linguist-vendored
+
+# Include Java files in the language statistics
+*.java          linguist-vendored=false
+
+# Ensure Dockerfile, YAML, and Gradle files are included
+Dockerfile      linguist-vendored=false
+*.yml           linguist-vendored=false
+*.yaml          linguist-vendored=false
+*.gradle        linguist-vendored=false


### PR DESCRIPTION
- Exclude CSS, SCSS, HTML, and JavaScript from language stats
- Ensure Dockerfile, Gradle, YAML, and Java are included
- Adjust linguist-vendored rules for better representation